### PR TITLE
avoid division in force function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,1 +1,2 @@
-AA added seconds() function to take timing of the force function
+AA added seconds() function to take timing of the force function. Took 26.583683 seconds with 108 atoms, almost 100% of the time taken by the whole program.
+AA (almost) removed division in the loop, took 22.009221 seconds. Use of perf record suggests that pow is a bottleneck.

--- a/src/force.c
+++ b/src/force.c
@@ -44,15 +44,16 @@ void force(mdsys_t *sys)
       
             /* compute force and energy if within cutoff */
             if (r < sys->rcut) {
-                ffac = -4.0*sys->epsilon*(-12.0*pow(sys->sigma/r,12.0)/r
-                                         +6*pow(sys->sigma/r,6.0)/r);
+		double rinv = 1/r;
+                ffac = -4.0*sys->epsilon*(-12.0*pow(sys->sigma*rinv,12.0)*rinv
+                                         +6*pow(sys->sigma*rinv,6.0)*rinv);
                 
-                sys->epot += 0.5*4.0*sys->epsilon*(pow(sys->sigma/r,12.0)
-                                               -pow(sys->sigma/r,6.0));
+                sys->epot += 0.5*4.0*sys->epsilon*(pow(sys->sigma*rinv,12.0)
+                                               -pow(sys->sigma*rinv,6.0));
 
-                sys->fx[i] += rx/r*ffac;
-                sys->fy[i] += ry/r*ffac;
-                sys->fz[i] += rz/r*ffac;
+                sys->fx[i] += rx*rinv*ffac;
+                sys->fy[i] += ry*rinv*ffac;
+                sys->fz[i] += rz*rinv*ffac;
             }
         }
     }


### PR DESCRIPTION
The flag -ffast-math has been removed since it gave wrong results.
